### PR TITLE
Add explicit interface for saving history with or without updating current session (backport)

### DIFF
--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -418,6 +418,11 @@ int main( int argc_, char** argv_ ) {
 			rx.history_add(input);
 			continue;
 
+		} else if (input.compare(0, 5, ".save") == 0) {
+			history_file = "replxx_history_alt.txt";
+			rx.history_save(history_file);
+			continue;
+
 		} else if (input.compare(0, 6, ".clear") == 0) {
 			// clear the screen
 			rx.clear_screen();
@@ -440,7 +445,7 @@ int main( int argc_, char** argv_ ) {
 	}
 
 	// save the history
-	rx.history_save(history_file);
+	rx.history_sync(history_file);
 
 	std::cout << "\nExiting Replxx\n";
 

--- a/include/replxx.h
+++ b/include/replxx.h
@@ -484,8 +484,44 @@ REPLXX_IMPEXP void replxx_set_max_history_size( Replxx*, int len );
 REPLXX_IMPEXP ReplxxHistoryScan* replxx_history_scan_start( Replxx* );
 REPLXX_IMPEXP void replxx_history_scan_stop( Replxx*, ReplxxHistoryScan* );
 REPLXX_IMPEXP int replxx_history_scan_next( Replxx*, ReplxxHistoryScan*, ReplxxHistoryEntry* );
-REPLXX_IMPEXP void replxx_history_save( Replxx*, const char* filename );
-REPLXX_IMPEXP void replxx_history_load( Replxx*, const char* filename );
+
+/*! \brief Synchronize REPL's history with given file.
+ *
+ * Synchronizing means loading existing history from given file,
+ * merging it with current history sorted by timestamps,
+ * saving merged version to given file,
+ * keeping merged version as current REPL's history.
+ *
+ * This call is an equivalent of calling:
+ * replxx_history_save( rx, "some-file" );
+ * replxx_history_load( rx, "some-file" );
+ *
+ * \param filename - a path to the file with which REPL's current history should be synchronized.
+ * \return 0 iff history file was successfully created, -1 otherwise.
+ */
+REPLXX_IMPEXP int replxx_history_sync( Replxx*, const char* filename );
+
+/*! \brief Save REPL's history into given file.
+ *
+ * Saving means loading existing history from given file,
+ * merging it with current history sorted by timestamps,
+ * saving merged version to given file,
+ * keeping original (NOT merged) version as current REPL's history.
+ *
+ * \param filename - a path to the file where REPL's history should be saved.
+ * \return 0 iff history file was successfully created, -1 otherwise.
+ */
+REPLXX_IMPEXP int replxx_history_save( Replxx*, const char* filename );
+
+/*! \brief Load REPL's history from given file.
+ *
+ * \param filename - a path to the file which contains REPL's history that should be loaded.
+ * \return 0 iff history file was successfully opened, -1 otherwise.
+ */
+REPLXX_IMPEXP int replxx_history_load( Replxx*, const char* filename );
+
+/*! \brief Clear REPL's in-memory history.
+ */
 REPLXX_IMPEXP void replxx_history_clear( Replxx* );
 REPLXX_IMPEXP void replxx_clear_screen( Replxx* );
 #ifdef __REPLXX_DEBUG__

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -468,8 +468,44 @@ public:
 	void bind_key( char32_t code, key_press_handler_t handler );
 
 	void history_add( std::string const& line );
-	void history_save( std::string const& filename );
-	void history_load( std::string const& filename );
+
+	/*! \brief Synchronize REPL's history with given file.
+	 *
+	 * Synchronizing means loading existing history from given file,
+	 * merging it with current history sorted by timestamps,
+	 * saving merged version to given file,
+	 * keeping merged version as current REPL's history.
+	 *
+	 * This call is an equivalent of calling:
+	 * history_save( "some-file" );
+	 * history_load( "some-file" );
+	 *
+	 * \param filename - a path to the file with which REPL's current history should be synchronized.
+	 * \return True iff history file was successfully created.
+	 */
+	bool history_sync( std::string const& filename );
+
+	/*! \brief Save REPL's history into given file.
+	 *
+	 * Saving means loading existing history from given file,
+	 * merging it with current history sorted by timestamps,
+	 * saving merged version to given file,
+	 * keeping original (NOT merged) version as current REPL's history.
+	 *
+	 * \param filename - a path to the file where REPL's history should be saved.
+	 * \return True iff history file was successfully created.
+	 */
+	bool history_save( std::string const& filename );
+
+	/*! \brief Load REPL's history from given file.
+	 *
+	 * \param filename - a path to the file which contains REPL's history that should be loaded.
+	 * \return True iff history file was successfully opened.
+	 */
+	bool history_load( std::string const& filename );
+
+	/*! \brief Clear REPL's in-memory history.
+	 */
 	void history_clear( void );
 	int history_size( void ) const;
 	HistoryScan history_scan( void ) const;

--- a/src/history.hxx
+++ b/src/history.hxx
@@ -78,8 +78,8 @@ private:
 public:
 	History( void );
 	void add( UnicodeString const& line, std::string const& when = now_ms_str() );
-	void save( std::string const& filename );
-	void load( std::string const& filename );
+	bool save( std::string const& filename, bool );
+	bool load( std::string const& filename );
 	void clear( void );
 	void set_max_size( int len );
 	void set_unique( bool unique_ ) {
@@ -131,9 +131,10 @@ private:
 	void trim_to_max_size( void );
 	void remove_duplicate( UnicodeString const& );
 	void remove_duplicates( void );
-	void do_load( std::string const& );
+	bool do_load( std::string const& );
 	entries_t::const_iterator last( void ) const;
 	void sort( void );
+	void reset_iters( void );
 };
 
 class Replxx::HistoryScanImpl {

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -145,12 +145,16 @@ void Replxx::history_add( std::string const& line ) {
 	_impl->history_add( line );
 }
 
-void Replxx::history_save( std::string const& filename ) {
-	_impl->history_save( filename );
+bool Replxx::history_sync( std::string const& filename ) {
+	return ( _impl->history_sync( filename ) );
 }
 
-void Replxx::history_load( std::string const& filename ) {
-	_impl->history_load( filename );
+bool Replxx::history_save( std::string const& filename ) {
+	return ( _impl->history_save( filename ) );
+}
+
+bool Replxx::history_load( std::string const& filename ) {
+	return ( _impl->history_load( filename ) );
 }
 
 void Replxx::history_clear( void ) {
@@ -519,9 +523,16 @@ int replxx_history_scan_next( ::Replxx*, ReplxxHistoryScan* historyScan_, Replxx
 
 /* Save the history in the specified file. On success 0 is returned
  * otherwise -1 is returned. */
-void replxx_history_save( ::Replxx* replxx_, const char* filename ) {
+int replxx_history_sync( ::Replxx* replxx_, const char* filename ) {
 	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
-	replxx->history_save( filename );
+	return ( replxx->history_sync( filename ) ? 0 : -1 );
+}
+
+/* Save the history in the specified file. On success 0 is returned
+ * otherwise -1 is returned. */
+int replxx_history_save( ::Replxx* replxx_, const char* filename ) {
+	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
+	return ( replxx->history_save( filename ) ? 0 : -1 );
 }
 
 /* Load the history from the specified file. If the file does not exist
@@ -529,9 +540,9 @@ void replxx_history_save( ::Replxx* replxx_, const char* filename ) {
  *
  * If the file exists and the operation succeeded 0 is returned, otherwise
  * on error -1 is returned. */
-void replxx_history_load( ::Replxx* replxx_, const char* filename ) {
+int replxx_history_load( ::Replxx* replxx_, const char* filename ) {
 	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
-	replxx->history_load( filename );
+	return ( replxx->history_load( filename ) ? 0 : -1 );
 }
 
 void replxx_history_clear( ::Replxx* replxx_ ) {

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -1983,12 +1983,16 @@ void Replxx::ReplxxImpl::history_add( std::string const& line ) {
 	_history.add( UnicodeString( line ) );
 }
 
-void Replxx::ReplxxImpl::history_save( std::string const& filename ) {
-	_history.save( filename );
+bool Replxx::ReplxxImpl::history_save( std::string const& filename ) {
+	return ( _history.save( filename, false ) );
 }
 
-void Replxx::ReplxxImpl::history_load( std::string const& filename ) {
-	_history.load( filename );
+bool Replxx::ReplxxImpl::history_sync( std::string const& filename ) {
+	return ( _history.save( filename, true ) );
+}
+
+bool Replxx::ReplxxImpl::history_load( std::string const& filename ) {
+	return ( _history.load( filename ) );
 }
 
 void Replxx::ReplxxImpl::history_clear( void ) {

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -151,8 +151,9 @@ public:
 	void set_hint_callback( Replxx::hint_callback_t const& fn );
 	char const* input( std::string const& prompt );
 	void history_add( std::string const& line );
-	void history_save( std::string const& filename );
-	void history_load( std::string const& filename );
+	bool history_sync( std::string const& filename );
+	bool history_save( std::string const& filename );
+	bool history_load( std::string const& filename );
 	void history_clear( void );
 	Replxx::HistoryScan::impl_t history_scan( void ) const;
 	int history_size( void ) const;

--- a/tests.py
+++ b/tests.py
@@ -1875,6 +1875,65 @@ class ReplxxTests( unittest.TestCase ):
 			)
 			self_.assertSequenceEqual( data[:-31], expected )
 			self_.assertSequenceEqual( data[-7:], ".merge\n" )
+	def test_history_save( self_ ):
+		with open( "replxx_history_alt.txt", "w" ) as f:
+			f.write(
+				"### 0000-00-00 00:00:00.001\n"
+				"one\n"
+				"### 0000-00-00 00:00:00.003\n"
+				"three\n"
+				"### 3000-00-00 00:00:00.005\n"
+				"other\n"
+				"### 3000-00-00 00:00:00.009\n"
+				"same\n"
+				"### 3000-00-00 00:00:00.017\n"
+				"seven\n"
+			)
+			f.close()
+		self_.check_scenario(
+			"zoom<cr>.save<cr><up><cr><c-d>",
+			"<c9>z<rst><ceos><c10><c9>zo<rst><ceos><c11><c9>zoo<rst><ceos><c12><c9>zoom<rst><ceos><c13><c9>zoom<rst><ceos><c13>\r\n"
+			"zoom\r\n"
+			"<brightgreen>replxx<rst>> "
+			"<c9><brightmagenta>.<rst><ceos><c10><c9><brightmagenta>.<rst>s<rst><ceos><c11><c9><brightmagenta>.<rst>sa<rst><ceos><c12><c9><brightmagenta>.<rst>sav<rst><ceos><c13><c9><brightmagenta>.<rst>save<rst><ceos><c14><c9><brightmagenta>.<rst>save<rst><ceos><c14>\r\n"
+			"<brightgreen>replxx<rst>> "
+			"<c9>zoom<rst><ceos><c13><c9>zoom<rst><ceos><c13>\r\n"
+			"zoom\r\n"
+		)
+	def test_bracketed_paste( self_ ):
+		self_.check_scenario(
+			"a0<paste-pfx>b1c2d3e<paste-sfx>4f<cr><c-d>",
+			"<c9>a<rst><ceos><c10>"
+			"<c9>a<brightmagenta>0<rst><ceos><c11>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<rst><ceos><c18>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst><ceos><c19>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst>f<rst><ceos><c20>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst>f<rst><ceos><c20>\r\n"
+			"a0b1c2d3e4f\r\n",
+			command = [ ReplxxTests._cSample_, "q1" ]
+		)
+		self_.check_scenario(
+			"a0<paste-pfx>b1c2d3e<paste-sfx>4f<cr><c-d>",
+			"<c9>a<rst><ceos><c10>"
+			"<c9>a<brightmagenta>0<rst><ceos><c11>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<rst><ceos><c18>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst><ceos><c19>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst>f<rst><ceos><c20>"
+			"<c9>a<brightmagenta>0<rst>b<brightmagenta>1<rst>c<brightmagenta>2<rst>d<brightmagenta>3<rst>e<brightmagenta>4<rst>f<rst><ceos><c20>\r\n"
+			"a0b1c2d3e4f\r\n",
+			command = [ ReplxxTests._cSample_, "q1", "B" ]
+		)
+		self_.check_scenario(
+			"a0<left><paste-pfx>/eb<paste-sfx><cr><paste-pfx>/db<paste-sfx><cr><paste-pfx>x<paste-sfx><cr><c-d>",
+			"<c9>a<rst><ceos><c10><c9>a<brightmagenta>0<rst><ceos><c11><c9>a<brightmagenta>0<rst><ceos><c10>"
+			"<c9>a/eb<brightmagenta>0<rst><ceos><c13><c9>a/eb<brightmagenta>0<rst><ceos><c14>\r\n"
+			"a/eb0\r\n"
+			"<brightgreen>replxx<rst>> <c9>/db<rst><ceos><c12><c9>/db<rst><ceos><c12>\r\n"
+			"/db\r\n"
+			"<brightgreen>replxx<rst>> <c9>x<rst><ceos><c10><c9>x<rst><ceos><c10>\r\n"
+			"x\r\n",
+			command = [ ReplxxTests._cSample_, "q1" ]
+		)
 
 def parseArgs( self, func, argv ):
 	global verbosity


### PR DESCRIPTION
Before this patch replxx, while saving to the history file always reload
the history from the disk and add new items from that file into the
current session. This looks incovenient, if user code calls
history_save() after each command (to save history ASAP, example of such
program is clickhouse-client) since if you run two programs with replxx
completion the completion will overlaps after each command.

Looks like at least this should be configurable.

Refs: https://github.com/ClickHouse/ClickHouse/pull/13086
Upstream PR: https://github.com/AmokHuginnsson/replxx/pull/83