### PR TITLE
Fix loading of multiline entries from the history

### DIFF
--- a/src/history.cxx
+++ b/src/history.cxx
@@ -178,22 +178,37 @@ bool History::do_load( std::string const& filename ) {
 	if ( ! histFile ) {
 		return ( false );
 	}
-	string line;
-	string when( "0000-00-00 00:00:00.000" );
-	while ( getline( histFile, line ).good() ) {
-		string::size_type eol( line.find_first_of( "\r\n" ) );
-		if ( eol != string::npos ) {
-			line.erase( eol );
-		}
-		if ( is_timestamp( line ) ) {
-			when.assign( line, 4, std::string::npos );
+
+	string current_line;
+	string history_line;
+	string when;
+
+	while ( getline( histFile, current_line ).good() ) {
+		if ( is_timestamp( current_line ) ) {
+			add_history_line( when, history_line );
+			when.assign( current_line, 4, string::npos );
 			continue;
 		}
-		if ( ! line.empty() ) {
-			_entries.emplace_back( when, UnicodeString( line ) );
-		}
+		history_line += current_line;
+		// Delimiter for multiline history entries
+		// (that is stripped by std::getline())
+		history_line += '\n';
 	}
+	add_history_line( when, history_line );
+
 	return ( true );
+}
+void History::add_history_line( std::string const& when, std::string& history_line )
+{
+	if ( history_line.empty() ) {
+		return;
+	}
+
+	string::size_type end( history_line.find_last_not_of( "\r\n" ) );
+	history_line.resize( end+1 );
+
+	_entries.emplace_back( when, UnicodeString( history_line ) );
+	history_line.clear();
 }
 
 bool History::load( std::string const& filename ) {

--- a/src/history.hxx
+++ b/src/history.hxx
@@ -132,6 +132,7 @@ private:
 	void remove_duplicate( UnicodeString const& );
 	void remove_duplicates( void );
 	bool do_load( std::string const& );
+	void add_history_line( std::string const&, std::string& );
 	entries_t::const_iterator last( void ) const;
 	void sort( void );
 	void reset_iters( void );


### PR DESCRIPTION
Before this patch multi-line entries stored like this in the history
file (use clickhouse-client -nm and paste "SELECT\n1;" there, with real
new line):

    ### 2021-01-03 16:06:33.215
    SELECT
    1;

But loaded separately, fix this by loading entry on timestamp change,
since each entry has it.