### PR TITLE
Improve bracketed paste

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -2402,17 +2402,21 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::clear_screen( char32_t c ) {
 }
 
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::bracketed_paste( char32_t ) {
+	static const UnicodeString BRACK_PASTE_SUFF( "\033[201~" );
+	static const int BRACK_PASTE_SLEN( BRACK_PASTE_SUFF.length() );
 	UnicodeString buf;
-	while ( char32_t c = _terminal.read_char() ) {
-		if ( c == KEY::PASTE_FINISH ) {
-			break;
-		}
+	while ( char32_t c = read_unicode_character() ) {
 		if ( ( c == '\r' ) || ( c == KEY::control( 'M' ) ) ) {
 			c = '\n';
-		} else if ( c == KEY::control( 'I' ) ) {
+		}
+		else if ( c == KEY::control( 'I' ) ) {
 			c = '\t';
 		}
 		buf.push_back( c );
+		if ( ( c == '~' ) && buf.ends_with( BRACK_PASTE_SUFF.begin(), BRACK_PASTE_SUFF.end() ) ) {
+			buf.erase( buf.length() - BRACK_PASTE_SLEN, BRACK_PASTE_SLEN );
+			break;
+		}
 	}
 	_data.insert( _pos, buf, 0, buf.length() );
 	_pos += buf.length();


### PR DESCRIPTION
Revert the upstream's implementation. Use our original one with much better performance and more compatible. Drawback: doesn't work for Windows.