### PR TITLE
Adjust replxx handle_hints function

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -877,9 +877,8 @@ void Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 #endif
 		startCol -= _hintContextLenght;
 		if ( startCol >= maxCol ) {
-                    startCol = startCol % maxCol;
-                }
-
+        	startCol = startCol % maxCol;
+        }
 		if ( _hintSelection < -1 ) {
 			_hintSelection = hintCount - 1;
 		} else if ( _hintSelection >= hintCount ) {

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -875,6 +875,11 @@ void Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 #ifdef _WIN32
 		-- maxCol;
 #endif
+		startCol -= _hintContextLenght;
+		if ( startCol >= maxCol ) {
+                    startCol = startCol % maxCol;
+                }
+
 		if ( _hintSelection < -1 ) {
 			_hintSelection = hintCount - 1;
 		} else if ( _hintSelection >= hintCount ) {
@@ -891,7 +896,6 @@ void Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 				set_color( Replxx::Color::DEFAULT );
 			}
 		}
-		startCol -= _hintContextLenght;
 		for ( int hintRow( 0 ); hintRow < min( hintCount, _maxHintRows ); ++ hintRow ) {
 #ifdef _WIN32
 			_display.push_back( '\r' );
@@ -918,6 +922,7 @@ void Replxx::ReplxxImpl::handle_hints( HINT_ACTION hintAction_ ) {
 			set_color( Replxx::Color::DEFAULT );
 		}
 	}
+	set_color(Replxx::Color::DEFAULT);
 	return;
 }
 
@@ -1080,7 +1085,7 @@ void Replxx::ReplxxImpl::repaint( void ) {
 	for ( int i( _prompt._extraLines ); i < _prompt._cursorRowOffset; ++ i ) {
 		_terminal.write8( "\n", 1 );
 	}
-	refresh_line( HINT_ACTION::SKIP );
+	refresh_line( HINT_ACTION::REPAINT );
 }
 
 void Replxx::ReplxxImpl::clear_self_to_end_of_screen( Prompt const* prompt_ ) {


### PR DESCRIPTION
There were some problems with replxx::handle_hints function. It was changing color for not only hints but also the user input itself + there were some problems with wrapped strings. Now they are fixed.