### PR TITLE
Fix nfds for select() in Terminal::wait_for_input()

### DIFF
--- a/src/terminal.cxx
+++ b/src/terminal.cxx
@@ -635,7 +635,7 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( int long timeout_ ) {
 	}
 #else
 	fd_set fdSet;
-	int nfds( max( _interrupt[0], _interrupt[1] ) + 1 );
+	int nfds( max( {_interrupt[0], _interrupt[1], _in_fd} ) + 1 );
 	while ( true ) {
 		FD_ZERO( &fdSet );
 		FD_SET( _in_fd, &fdSet );


### PR DESCRIPTION
As you can see here we have only one fd, but there should be always two, the reason is likely due to nfds does not take into account the _in_fd, which can be bigger then the _interrupt pipe:

    # strace -p 459247
    strace: Process 459247 attached
    pselect6(201, [179], NULL, NULL, NULL, NULL^Cstrace: Process 459247 detached
     <detached ...>

Refs: https://github.com/ClickHouse/ClickHouse/issues/80684
Upstream: https://github.com/AmokHuginnsson/replxx/pull/161