### PR TITLE
Fix possible crash in History::erase()

### DIFF
--- a/src/history.cxx
+++ b/src/history.cxx
@@ -352,6 +352,7 @@ History::entries_t::iterator History::moved( entries_t::iterator it_, int by_, b
 
 void History::erase( entries_t::iterator it_ ) {
 	bool invalidated( it_ == _current );
+	it_->reset_scratch();
 	_locations.erase( it_->text() );
 	it_ = _entries.erase( it_ );
 	if ( invalidated ) {


### PR DESCRIPTION
The problem was that you can remove different entries from _locations and _entries in case of Entry::_scratch does not match Entry::_text (i.e. after some modifications of existing entries in history)

And you will get heap-use-after-free in this case:

    =================================================================
    ==21751==ERROR: AddressSanitizer: heap-use-after-free on address 0x508000077be0 at pc 0x5555908ad5e9 bp 0x7fffffffa2c0 sp 0x7fffffffa2b8
    READ of size 8 at 0x508000077be0 thread T0
        #0 0x5555908ad5e8 in std::__1::vector<>::data[abi:ne190107]() const ci/tmp/build/./contrib/llvm-project/libcxx/include/vector:674:36
        #1 0x5555908ad5e8 in replxx::UnicodeString::get() const ci/tmp/build/./contrib/replxx/src/unicodestring.hxx:148:16
        #2 0x5555908ad5e8 in std::__1::hash<replxx::UnicodeString>::operator()(replxx::UnicodeString const&) const ci/tmp/build/./contrib/replxx/src/history.hxx:17:26
        #3 0x5555908ad5e8 in ci/tmp/build/./contrib/llvm-project/libcxx/include/unordered_map:646:75
        #4 0x5555908ad5e8 in ci/tmp/build/./contrib/llvm-project/libcxx/include/__hash_table:1748:20
        #5 0x55559089c55b in ci/tmp/build/./contrib/llvm-project/libcxx/include/__hash_table:1851:18
        #6 0x55559089c55b in ci/tmp/build/./contrib/llvm-project/libcxx/include/unordered_map:1322:80
        #7 0x55559089c55b in replxx::History::erase(std::__1::__list_iterator<replxx::History::Entry, void*>) ci/tmp/build/./contrib/replxx/src/history.cxx:355:13
        #8 0x55559089c55b in replxx::History::remove_duplicate(replxx::UnicodeString const&) ci/tmp/build/./contrib/replxx/src/history.cxx:381:2
        #9 0x55559089b9ab in replxx::History::add(replxx::UnicodeString const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/replxx/src/history.cxx:94:2
        #10 0x5555908e9d70 in replxx::Replxx::ReplxxImpl::history_add(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/replxx/src/replxx_impl.cxx:2467:11
        #11 0x555586b4dc4f in DB::ReplxxLineReader::addToHistory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/ReplxxLineReader.cpp:527:8
        #12 0x555586b11f7f in DB::LineReader::readLine(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/LineReader.cpp:217:9
        #13 0x555586a4445e in DB::ClientBase::runInteractive() ci/tmp/build/./src/Client/ClientBase.cpp:3335:25

    0x508000077be0 is located 64 bytes inside of 88-byte region [0x508000077ba0,0x508000077bf8)
    freed by thread T0 here:
        #0 0x55556193a622 in operator delete(void*, unsigned long) (/src/ch/tmp/ci/clickhouse+0xc3e6622) (BuildId: 6b920302e2b03137aca21bee17dec6310aedbafa)
        #1 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/new:274:3
        #2 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/new:298:10
        #3 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/new:311:12
        #4 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/allocator.h:132:7
        #5 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/__memory/allocator_traits.h:312:9
        #6 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/list:574:5
        #7 0x55559089c60c in ci/tmp/build/./contrib/llvm-project/libcxx/include/list:1341:9
        #8 0x55559089c60c in replxx::History::erase(std::__1::__list_iterator<replxx::History::Entry, void*>) ci/tmp/build/./contrib/replxx/src/history.cxx:356:17
        #9 0x55559089c60c in replxx::History::remove_duplicate(replxx::UnicodeString const&) ci/tmp/build/./contrib/replxx/src/history.cxx:381:2
        #10 0x55559089b9ab in replxx::History::add(replxx::UnicodeString const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/replxx/src/history.cxx:94:2
        #11 0x5555908e9d70 in replxx::Replxx::ReplxxImpl::history_add(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./contrib/replxx/src/replxx_impl.cxx:2467:11
        #12 0x555586b4dc4f in DB::ReplxxLineReader::addToHistory(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/ReplxxLineReader.cpp:527:8
        #13 0x555586b11f7f in DB::LineReader::readLine(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) ci/tmp/build/./src/Client/LineReader.cpp:217:9
        #14 0x555586a4445e in DB::ClientBase::runInteractive() ci/tmp/build/./src/Client/ClientBase.cpp:3335:25

    SUMMARY: AddressSanitizer: heap-use-after-free ci/tmp/build/./contrib/llvm-project/libcxx/include/vector:674:36 in std::__1::vector<char32_t, std::__1::allocator<char32_t>>::data[abi:ne190107]() const

Upstream: https://github.com/AmokHuginnsson/replxx/pull/160