### PR TITLE
Fix out-of-bounds access in `do_complete_line` when `_hintSelection` is stale

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -1169,7 +1169,7 @@ char32_t Replxx::ReplxxImpl::do_complete_line( bool showCompletions_ ) {
 	int longestCommonPrefix = 0;
 	int completionsCount( static_cast<int>( _completions.size() ) );
 	int selectedCompletion( 0 );
-	if ( ( completionsCount > 1 ) && ( _hintSelection != -1 ) ) {
+	if ( ( completionsCount > 1 ) && ( _hintSelection >= 0 ) && ( _hintSelection < completionsCount ) ) {
 		selectedCompletion = _hintSelection;
 		completionsCount = 1;
 	}


### PR DESCRIPTION
`_hintSelection` can become an invalid index (e.g. -2) when `hint_move` is triggered (via Ctrl+Up/Down) without a hint callback set. Since `handle_hints` returns early when `_hintCallback` is null, `_hintSelection` is never clamped back to a valid range.

When Tab is then pressed, `do_complete_line` used `_hintSelection` as an index into `_completions` without bounds checking, causing a vector[] out-of-bounds crash.

Fix by validating `_hintSelection` is within [0, completionsCount) before using it as an index.