### PR TITLE
Fix crash due to hitting FD_SETSIZE limitation of select() (replace with poll())

### DIFF
--- a/src/terminal.cxx
+++ b/src/terminal.cxx
@@ -26,9 +26,10 @@ static DWORD const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4;
 
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <limits.h>
 
 #endif /* _WIN32 */
 
@@ -634,21 +635,25 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( int long timeout_ ) {
 		}
 	}
 #else
-	fd_set fdSet;
-	int nfds( max( {_interrupt[0], _interrupt[1], _in_fd} ) + 1 );
+	pollfd fds[2];
+	fds[0].fd = _in_fd;
+	fds[0].events = POLLIN;
+	fds[1].fd = _interrupt[0];
+	fds[1].events = POLLIN;
+	int const poll_timeout( timeout_ > 0
+		? ( timeout_ > INT_MAX ? INT_MAX : static_cast<int>( timeout_ ) )
+		: -1 );
 	while ( true ) {
-		FD_ZERO( &fdSet );
-		FD_SET( _in_fd, &fdSet );
-		FD_SET( _interrupt[0], &fdSet );
-		timeval tv{ timeout_ / 1000, static_cast<suseconds_t>( ( timeout_ % 1000 ) * 1000 ) };
-		int err( select( nfds, &fdSet, nullptr, nullptr, timeout_ > 0 ? &tv : nullptr ) );
+		fds[0].revents = 0;
+		fds[1].revents = 0;
+		int err( poll( fds, 2, poll_timeout ) );
 		if ( ( err == -1 ) && ( errno == EINTR ) ) {
 			continue;
 		}
 		if ( err == 0 ) {
 			return ( EVENT_TYPE::TIMEOUT );
 		}
-		if ( FD_ISSET( _interrupt[0], &fdSet ) ) {
+		if ( fds[1].revents & ( POLLIN | POLLHUP | POLLERR ) ) {
 			char data( 0 );
 			static_cast<void>( read( _interrupt[0], &data, 1 ) == 1 );
 			if ( data == 'k' ) {
@@ -661,7 +666,7 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( int long timeout_ ) {
 				return ( EVENT_TYPE::RESIZE );
 			}
 		}
-		if ( FD_ISSET( _in_fd, &fdSet ) ) {
+		if ( fds[0].revents & ( POLLIN | POLLHUP | POLLERR ) ) {
 			return ( EVENT_TYPE::KEY_PRESS );
 		}
 	}


### PR DESCRIPTION
When replxx is embedded into a long-running multi-fd process such as clickhouse-server, the PTY input fd and the internal _interrupt pipe fds can be allocated above FD_SETSIZE (1024). FD_SET/FD_ISSET then read/write past the end of the on-stack `fd_set`, observed as an ASan stack-buffer-overflow inside replxx::Terminal::wait_for_input and as non-deterministic hangs / SIGSEGVs in release builds. poll(2) has no fd-number limit.