### PR TITLE
Handle POLLNVAL in Terminal::wait_for_input

### DIFF
--- a/src/terminal.cxx
+++ b/src/terminal.cxx
@@ -653,7 +653,8 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( int long timeout_ ) {
 		if ( err == 0 ) {
 			return ( EVENT_TYPE::TIMEOUT );
 		}
-		if ( fds[1].revents & ( POLLIN | POLLHUP | POLLERR ) ) {
+		short const ready_mask( POLLIN | POLLHUP | POLLERR | POLLNVAL );
+		if ( fds[1].revents & ready_mask ) {
 			char data( 0 );
 			static_cast<void>( read( _interrupt[0], &data, 1 ) == 1 );
 			if ( data == 'k' ) {
@@ -666,7 +667,7 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( int long timeout_ ) {
 				return ( EVENT_TYPE::RESIZE );
 			}
 		}
-		if ( fds[0].revents & ( POLLIN | POLLHUP | POLLERR ) ) {
+		if ( fds[0].revents & ready_mask ) {
 			return ( EVENT_TYPE::KEY_PRESS );
 		}
 	}


### PR DESCRIPTION
`poll` reports `POLLNVAL` immediately when a watched fd has been closed or otherwise become invalid (for example, after a PTY teardown). The previous masks only covered `POLLIN | POLLHUP | POLLERR`, so neither branch fired and the `while (true)` loop spun at 100% CPU. Add `POLLNVAL` to the mask so the invalid fd is treated the same as a terminal/error condition - we read what we can from the interrupt pipe or surface a key-press event for the input fd, which lets the caller unwind cleanly.