### PR TITLE
Add functionality to return prompt's indentation

### DIFF
--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -610,6 +610,8 @@ public:
 
 	void set_subword_break_characters( char const* wordBreakers );
 
+	int prompt_indentation( void );
+
 	/*! \brief How many completions should trigger pagination.
 	 */
 	void set_completion_count_cutoff( int count );

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -275,6 +275,10 @@ void Replxx::bind_key_internal( char32_t keyPress_, char const* actionName_, int
 	_impl->bind_key_internal( keyPress_, actionName_, editingMode_ );
 }
 
+int Replxx::prompt_indentation( void ) {
+	return _impl->prompt_indentation();
+}
+
 Replxx::State Replxx::get_state( void ) const {
 	return ( _impl->get_state() );
 }

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -2783,6 +2783,10 @@ void Replxx::ReplxxImpl::set_escdelay( int delay ) {
 	_terminal.set_escdelay( delay );
 }
 
+int Replxx::ReplxxImpl::prompt_indentation( void ) {
+	return _prompt.indentation();
+}
+
 /**
  * Display the dynamic incremental search prompt and the current user input
  * line.

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -213,6 +213,7 @@ public:
 	Replxx::State get_state( void ) const;
 	void set_state( Replxx::State const& );
 	void set_ignore_case( bool val );
+	int prompt_indentation( void );
 private:
 	ReplxxImpl( ReplxxImpl const& ) = delete;
 	ReplxxImpl& operator = ( ReplxxImpl const& ) = delete;


### PR DESCRIPTION
This is needed to handle some things externally in the vim mode implementation that I'm working on.